### PR TITLE
feat(frontend): implement global auth store with Zustand

### DIFF
--- a/frontend/src/app/cards/page.tsx
+++ b/frontend/src/app/cards/page.tsx
@@ -1,6 +1,7 @@
 // src/app/cards/page.tsx
 "use client";
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
+import { useAuthStore } from '@/store/useAuthStore';
 
 import type { Card } from '@/types';
 import { useCardsStore } from '@/store/useCardsStore';
@@ -50,13 +51,8 @@ function SortableCard({ card, editMode }: SortableCardProps) {
 
 export default function CardsPage() {
   const [editMode, setEditMode] = useState(false);
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
   const cards = useCardsStore((state) => state.cards);
-
-  useEffect(() => {
-    const token = localStorage.getItem('auth_token');
-    setIsLoggedIn(!!token);
-  }, []);
+  const isLoggedIn = useAuthStore((s) => s.isLoggedIn);
 
   if (!isLoggedIn) {
     return (

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,10 +1,11 @@
 // src/app/page.tsx
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { getCardRec } from '@/app/api/user';
 import { useCardsStore } from '@/store/useCardsStore';
 import CreditCardItem from '@/components/CreditCardItem';
+import { useAuthStore } from '@/store/useAuthStore';
 import type { Card, Category } from '@/types';
 
 export default function Home() {
@@ -13,14 +14,9 @@ export default function Home() {
   const [error, setError] = useState<string | null>(null);
   const [category, setCategory] = useState<string | null>(null);
   const [bestCards, setBestCards] = useState<Card[]>([]);
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
 
   const cards = useCardsStore((state) => state.cards);
-
-  useEffect(() => {
-    const token = localStorage.getItem('auth_token');
-    setIsLoggedIn(!!token);
-  }, []);
+  const isLoggedIn = useAuthStore((s) => s.isLoggedIn);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/src/app/visualize/page.tsx
+++ b/frontend/src/app/visualize/page.tsx
@@ -1,18 +1,13 @@
 // src/app/visualize/page.tsx
 "use client";
 
-import { useEffect, useState } from 'react';
 import { useCardsStore } from '@/store/useCardsStore';
+import { useAuthStore } from '@/store/useAuthStore';
 import CoverageVisualizer from '@/components/CoverageVisualizer';
 
 export default function VisualizePage() {
   const cards = useCardsStore((state) => state.cards);
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
-
-  useEffect(() => {
-    const token = localStorage.getItem('auth_token');
-    if (token) setIsLoggedIn(true);
-  }, []);
+  const isLoggedIn = useAuthStore((s) => s.isLoggedIn);
 
   if (!isLoggedIn) {
     return (

--- a/frontend/src/components/LoginModal.tsx
+++ b/frontend/src/components/LoginModal.tsx
@@ -4,7 +4,7 @@
 import { useState } from 'react';
 import { loginOrSignup } from '../app/api/auth';
 import { loadUserCardsToStore } from '@/lib/loadUserCards';
-import { useRouter } from 'next/navigation';
+import { useAuthStore } from '@/store/useAuthStore';
 
 export default function LoginModal({ onClose }: { onClose: () => void }) {
   const [username, setUsername] = useState('');
@@ -13,7 +13,7 @@ export default function LoginModal({ onClose }: { onClose: () => void }) {
   const [loading, setLoading] = useState(false);
   const [isLogin, setIsLogin] = useState(true);
 
-  const router = useRouter();
+  const setLoggedIn = useAuthStore((s) => s.setLoggedIn);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -26,7 +26,7 @@ export default function LoginModal({ onClose }: { onClose: () => void }) {
       if (response.token) {
         localStorage.setItem('auth_token', response.token);
         await loadUserCardsToStore();
-        router.refresh();
+        setLoggedIn(true);
       }
       onClose();
     } else {

--- a/frontend/src/components/navbar.tsx
+++ b/frontend/src/components/navbar.tsx
@@ -3,33 +3,29 @@
 import Link from 'next/link';
 import { useTheme } from 'next-themes';
 import { useEffect, useState } from 'react';
+import { useAuthStore } from '@/store/useAuthStore';
 import LoginModal from './LoginModal';
-
-import { useRouter } from 'next/navigation';
 
 export default function Navbar() {
   const { theme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
   const [showLogin, setShowLogin] = useState(false);
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
 
-  const router = useRouter();
+  const isLoggedIn = useAuthStore((s) => s.isLoggedIn);
+  const setLoggedIn = useAuthStore((s) => s.setLoggedIn);
+  const authInit = useAuthStore((s) => s.initializeAuth);
 
   useEffect(() => {
     setMounted(true);
-    const token = localStorage.getItem('auth_token');
-    setIsLoggedIn(!!token);
-  }, []);
+    authInit();
+  }, [authInit]);
 
   const handleSignOut = () => {
     localStorage.removeItem('auth_token');
-    setIsLoggedIn(false);
-    router.refresh();
+    setLoggedIn(false);
   };
 
   const handleLoginClose = () => {
-    const token = localStorage.getItem('auth_token');
-    setIsLoggedIn(!!token);
     setShowLogin(false);
   };
 

--- a/frontend/src/store/useAuthStore.ts
+++ b/frontend/src/store/useAuthStore.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand';
+
+interface AuthState {
+  isLoggedIn: boolean;
+  setLoggedIn: (value: boolean) => void;
+  initializeAuth: () => void;
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  isLoggedIn: false,
+
+  setLoggedIn: (value) => set({ isLoggedIn: value }),
+
+  // initialize from localStorage (to call once on app load)
+  initializeAuth: () => {
+    const token = localStorage.getItem('auth_token');
+    set({ isLoggedIn: !!token });
+  },
+}));


### PR DESCRIPTION
## Summary
- add `useAuthStore` for login state and initialization
- update navbar, login modal, and pages to use global auth

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689037b81c2c8324b2358f23b8171fe0