### PR TITLE
Aggregate card rewards and filter by category in SQL

### DIFF
--- a/backend/routes/cards.js
+++ b/backend/routes/cards.js
@@ -8,48 +8,52 @@ router.get('/', async (req, res) => {
   const { search, issuer, network, annual_fee, reward_category } = req.query;
 
   let query = `
-    SELECT * FROM cards
+    SELECT c.*, COALESCE(json_agg(row_to_json(cr)) FILTER (WHERE cr.id IS NOT NULL), '[]') AS rewards
+    FROM cards c
+    LEFT JOIN card_rewards cr ON c.id = cr.card_id
     WHERE 1=1
   `;
   const params = [];
 
   if (search) {
-    query += ` AND LOWER(name) LIKE LOWER($${params.length + 1})`;
+    query += ` AND LOWER(c.name) LIKE LOWER($${params.length + 1})`;
     params.push(`%${search}%`);
   }
 
   if (issuer) {
-    query += ` AND issuer = $${params.length + 1}`;
+    query += ` AND c.issuer = $${params.length + 1}`;
     params.push(issuer);
   }
 
   if (network) {
-    query += ` AND network = $${params.length + 1}`;
+    query += ` AND c.network = $${params.length + 1}`;
     params.push(network);
   }
 
   if (annual_fee) {
     if (annual_fee === '0') {
-      query += ` AND annual_fee = 0`;
+      query += ` AND c.annual_fee = 0`;
     } else if (annual_fee === '<100') {
-      query += ` AND annual_fee < 100`;
+      query += ` AND c.annual_fee < 100`;
     } else if (annual_fee === '>=100') {
-      query += ` AND annual_fee >= 100`;
+      query += ` AND c.annual_fee >= 100`;
     }
   }
+
+  if (reward_category) {
+    query += ` AND EXISTS (
+      SELECT 1 FROM card_rewards cr2
+      WHERE cr2.card_id = c.id AND LOWER(cr2.category) = LOWER($${params.length + 1})
+    )`;
+    params.push(reward_category);
+  }
+
+  query += ` GROUP BY c.id`;
 
   const cardsResult = await pool.query(query, params);
   const cards = cardsResult.rows;
 
-  // Filter by reward category if requested
-  let filteredCards = cards;
-  if (reward_category) {
-    filteredCards = cards.filter((card) =>
-      card.rewards.some((r) => r.category.toLowerCase() === reward_category.toLowerCase())
-    );
-  }
-
-  res.json({ cards: filteredCards });
+  res.json({ cards });
 });
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- Join `card_rewards` with `cards` and aggregate rewards per card
- Filter by reward category directly in SQL instead of in application logic

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6899382d4e148324bee573f6973b1e2e