### PR TITLE
Refactor card rewards to array-based structure

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -8,6 +8,9 @@ import CreditCardItem from '@/components/CreditCardItem';
 import { useAuthStore } from '@/store/useAuthStore';
 import type { Card, Category } from '@/types';
 
+const getRewardValue = (card: Card, category: string): number =>
+  card.rewards.find((r) => r.category === category)?.multiplier ?? 0;
+
 export default function Home() {
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
@@ -41,12 +44,12 @@ export default function Home() {
 
       let maxReward = 0;
       for (const card of cards) {
-        const reward = card.rewards[key] ?? card.rewards['All'] ?? 0;
+        const reward = Math.max(getRewardValue(card, key), getRewardValue(card, 'All'));
         if (reward > maxReward) maxReward = reward;
       }
 
       const matching = cards.filter((card) => {
-        const reward = card.rewards[key] ?? card.rewards['All'] ?? 0;
+        const reward = Math.max(getRewardValue(card, key), getRewardValue(card, 'All'));
         return reward === maxReward && reward > 0;
       });
 

--- a/frontend/src/components/AddCardModal.tsx
+++ b/frontend/src/components/AddCardModal.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useState } from 'react';
 import CreditCardItem from './CreditCardItem';
 import { useCardsStore } from '@/store/useCardsStore';
-import { Rewards } from '@/types';
+import type { Reward } from '@/types';
 
 interface Card {
   id: string;
@@ -13,7 +13,7 @@ interface Card {
   network: string;
   annual_fee: number;
   image_url: string;
-  rewards: Rewards;
+  rewards: Reward[];
   notes: string;
 }
 

--- a/frontend/src/components/CoverageVisualizer.tsx
+++ b/frontend/src/components/CoverageVisualizer.tsx
@@ -18,16 +18,7 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 
-import { Rewards } from '@/types';
-
-interface Card {
-  id: string;
-  name: string;
-  image_url: string;
-  rewards: Rewards;
-  annual_fee: number;
-  notes: string;
-}
+import type { Card } from '@/types';
 
 interface Props {
   cards: Card[];
@@ -43,6 +34,9 @@ const allCategories = [
   'Transit',
   'Utilities',
 ];
+
+const getRewardValue = (card: Card, category: string): number =>
+  card.rewards.find((r) => r.category === category)?.multiplier ?? 0;
 
 function DraggableRow({ id, children }: { id: string; children: React.ReactNode }) {
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id });
@@ -143,8 +137,8 @@ export default function CoverageVisualizer({ cards }: Props) {
                   let bestReward = 0;
                   for (const card of cards) {
                     const reward = Math.max(
-                      card.rewards[category as keyof Rewards] ?? 0,
-                      card.rewards['All'] ?? 0
+                      getRewardValue(card, category),
+                      getRewardValue(card, 'All')
                     );
                     if (reward > bestReward) {
                       bestReward = reward;
@@ -204,16 +198,16 @@ export default function CoverageVisualizer({ cards }: Props) {
             <tbody>
               {sortedCategories.map((category, categoryIndex) => {
                 const rowRewards = sortedCards.map((card) => {
-                  const categoryReward = card.rewards[category as keyof Rewards];
-                  const allReward = card.rewards['All'];
-                  return Math.max(categoryReward ?? 0, allReward ?? 0);
+                  const categoryReward = getRewardValue(card, category);
+                  const allReward = getRewardValue(card, 'All');
+                  return Math.max(categoryReward, allReward);
                 });
                 const maxReward = Math.max(...rowRewards);
 
                 const bestInCard: number[] = sortedCards.map((card) => {
                   let best = 0;
                   for (const cat of allCategories) {
-                    const r = Math.max(card.rewards[cat as keyof Rewards] ?? 0, card.rewards['All'] ?? 0);
+                    const r = Math.max(getRewardValue(card, cat), getRewardValue(card, 'All'));
                     if (r > best) best = r;
                   }
                   return best;
@@ -229,9 +223,9 @@ export default function CoverageVisualizer({ cards }: Props) {
                       {category}
                     </td>
                     {sortedCards.map((card, colIndex) => {
-                      const categoryReward = card.rewards[category as keyof Rewards];
-                      const allReward = card.rewards['All'];
-                      const reward = Math.max(categoryReward ?? 0, allReward ?? 0);
+                      const categoryReward = getRewardValue(card, category);
+                      const allReward = getRewardValue(card, 'All');
+                      const reward = Math.max(categoryReward, allReward);
                       const intensity = reward ? Math.min(reward / 5, 1) : 0;
                       const bgColor = reward ? getHeatColor(intensity) : 'transparent';
 

--- a/frontend/src/components/CreditCardItem.tsx
+++ b/frontend/src/components/CreditCardItem.tsx
@@ -40,8 +40,8 @@ export default function CreditCardItem({ card, editMode }: CardProps) {
             <h3 className="text-xl font-semibold mb-1">{card.name}</h3>
             <p className="text-sm text-gray-600 dark:text-gray-300 mb-1">
             <strong>Rewards:</strong>{" "}
-            {Object.entries(card.rewards)
-                .map(([category, multiplier]) => `${multiplier}x ${category}`)
+            {card.rewards
+                .map((r) => `${r.multiplier}x ${r.category}`)
                 .join(', ')}
             </p>
             <p className="text-sm text-gray-600 dark:text-gray-300 mb-1">

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -11,15 +11,22 @@ export type Category =
   | 'Utilities'
   | 'All';
 
-export type Rewards = {
-  [key in Category]?: number;
-};
+export interface Reward {
+  category: Category;
+  multiplier: number;
+  reward_type?: string;
+  cap?: number | null;
+  portal_only?: boolean;
+  start_date?: string | null;
+  end_date?: string | null;
+  notes?: string;
+}
 
 export interface Card {
   id: string;
   name: string;
   image_url: string;
-  rewards: Rewards;
+  rewards: Reward[];
   annual_fee: number;
   notes: string;
 }


### PR DESCRIPTION
## Summary
- replace `Rewards` map with explicit `Reward` objects and update `Card` interface
- adjust UI components (AddCardModal, CoverageVisualizer, CreditCardItem) to read rewards arrays
- update home page logic to compute best cards using helper lookup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68993831ee8083249d389d45cfa1b03c