### PR TITLE
Fix card management issues

### DIFF
--- a/frontend/src/app/cards/page.tsx
+++ b/frontend/src/app/cards/page.tsx
@@ -56,14 +56,14 @@ export default function CardsPage() {
   const cards = useCardsStore((state) => state.cards);
   const isLoggedIn = useAuthStore((s) => s.isLoggedIn);
 
-  // if (!isLoggedIn) {
-  //   return (
-  //     <main className="p-6 max-w-2xl mx-auto">
-  //       <h2 className="text-2xl font-semibold mb-4">Your Cards</h2>
-  //       <p className="text-gray-600 dark:text-gray-300">Log in to view and manage your saved cards.</p>
-  //     </main>
-  //   );
-  // }
+  if (!isLoggedIn) {
+    return (
+      <main className="p-6 max-w-2xl mx-auto">
+        <h2 className="text-2xl font-semibold mb-4">Your Cards</h2>
+        <p className="text-gray-600 dark:text-gray-300">Log in to view and manage your saved cards.</p>
+      </main>
+    );
+  }
 
   if (cards.length === 0) {
     return (

--- a/frontend/src/components/AddCardModal.tsx
+++ b/frontend/src/components/AddCardModal.tsx
@@ -4,26 +4,23 @@
 import { useEffect, useState } from 'react';
 import CreditCardItem from './CreditCardItem';
 import { useCardsStore } from '@/store/useCardsStore';
-import type { Reward } from '@/types';
+import type { Card } from '@/types';
 
-interface Card {
-  id: string;
-  name: string;
+interface ApiCard extends Card {
   issuer: string;
   network: string;
-  annual_fee: number;
-  image_url: string;
-  rewards: Reward[];
-  notes: string;
 }
 
 export default function AddCardModal({ onClose }: { onClose: () => void }) {
   const [search, setSearch] = useState('');
-  const [searchResults, setSearchResults] = useState<Card[]>([]);
-  const [selectedCard, setSelectedCard] = useState<Card | null>(null);
+  const [searchResults, setSearchResults] = useState<ApiCard[]>([]);
+  const [selectedCard, setSelectedCard] = useState<ApiCard | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const userCards = useCardsStore((state) => state.cards);
+  const { cards: userCards, setCards } = useCardsStore((state) => ({
+    cards: state.cards,
+    setCards: state.setCards,
+  }));
 
   const [annualFee, setAnnualFee] = useState('');
   const [issuer, setIssuer] = useState('');
@@ -65,6 +62,7 @@ export default function AddCardModal({ onClose }: { onClose: () => void }) {
       },
       body: JSON.stringify({ card_id: selectedCard.id }),
     });
+    setCards([...userCards, selectedCard]);
     setLoading(false);
     onClose();
   };

--- a/frontend/src/components/CreditCardItem.tsx
+++ b/frontend/src/components/CreditCardItem.tsx
@@ -40,9 +40,9 @@ export default function CreditCardItem({ card, editMode }: CardProps) {
             <h3 className="text-xl font-semibold mb-1">{card.name}</h3>
             <p className="text-sm text-gray-600 dark:text-gray-300 mb-1">
             <strong>Rewards:</strong>{" "}
-            {card.rewards
-                ? Object.entries(card.rewards ?? {})
-                    .map(([category, multiplier]) => `${multiplier}x ${category}`)
+            {card.rewards && card.rewards.length > 0
+                ? card.rewards
+                    .map((reward) => `${reward.multiplier}x ${reward.category}`)
                     .join(', ')
                 : 'No rewards'}
             </p>


### PR DESCRIPTION
## Summary
- check login state in My Cards page before showing card list
- display card rewards with category and multiplier
- update user card store after adding a new card

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689950b17c0083248938c052b8fb4320