### PR TITLE
Fix card deletion refresh and clean up unused API code

### DIFF
--- a/frontend/src/app/api/user.ts
+++ b/frontend/src/app/api/user.ts
@@ -82,26 +82,6 @@ export const getCardRec = async (description: string): Promise<string> => {
   return data.category;
 };
 
-export const addUserCard = async (cardId: string) => {
-  const token = localStorage.getItem('auth_token');
-
-  const res = await fetch(`${API_BASE_URL}/api/user-cards`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${token}`,
-    },
-    body: JSON.stringify({ card_id: cardId }),
-  });
-
-  const data: { success: boolean; message?: string } = await res.json();
-  if (!res.ok || !data.success) {
-    throw new Error(data.message || 'Failed to add card');
-  }
-
-  return data;
-};
-
 export const searchCards = async (params: {
   search?: string;
   annual_fee?: string;

--- a/frontend/src/app/cards/page.tsx
+++ b/frontend/src/app/cards/page.tsx
@@ -1,6 +1,7 @@
 // src/app/cards/page.tsx
 "use client";
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { useAuthStore } from '@/store/useAuthStore';
 
 import type { Card } from '@/types';
@@ -53,9 +54,11 @@ function SortableCard({ card, editMode, onDelete }: SortableCardProps) {
 }
 
 export default function CardsPage() {
+  const router = useRouter();
   const [editMode, setEditMode] = useState(false);
   const [showModal, setShowModal] = useState(false);
-  const cards = useCardsStore((state) => state.cards);const removeCard = useCardsStore((state) => state.removeCard);
+  const cards = useCardsStore((state) => state.cards);
+  const removeCard = useCardsStore((state) => state.removeCard);
   const isLoggedIn = useAuthStore((s) => s.isLoggedIn);
 
   if (!isLoggedIn) {
@@ -96,6 +99,7 @@ export default function CardsPage() {
     try {
       await removeUserCard(cardId);
       removeCard(cardId);
+      router.refresh();
     } catch (error) {
       console.error('Failed to delete card:', error);
     }

--- a/frontend/src/components/AddCardModal.tsx
+++ b/frontend/src/components/AddCardModal.tsx
@@ -4,9 +4,7 @@
 import { useEffect, useState } from 'react';
 import CreditCardItem from './CreditCardItem';
 import { useCardsStore } from '@/store/useCardsStore';
-import { saveUserCard } from '@/app/api/user';
-
-import { addUserCard, searchCards, type ApiCard } from '@/app/api/user';
+import { saveUserCard, searchCards, type ApiCard } from '@/app/api/user';
 
 export default function AddCardModal({ onClose }: { onClose: () => void }) {
   const [search, setSearch] = useState('');


### PR DESCRIPTION
## Summary
- Refresh card list after deletion so removed cards disappear immediately
- Remove unused `addUserCard` API and consolidate imports

## Testing
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run lint`
- `npm test` (backend) *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a73bfc5e48324bbe0a0f10156e4b3